### PR TITLE
Add Home Assistant config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-Needs populating
+# HaWoManager
+
+This repository contains a custom Home Assistant integration called **WO Manager**. It includes a configuration flow that guides you through adding devices from Home Assistant's UI.
+
+## Usage
+
+Copy the `custom_components/womgr` folder to your Home Assistant `custom_components` directory. Restart Home Assistant and use **Add Device** from the integrations page to register a new machine. You will be asked for:
+
+- Device name
+- MAC address
+- IP address
+- Operating system type
+- Credentials method (password or SSH key)
+
+The information is stored in Home Assistant's configuration entries for later use.

--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -1,0 +1,3 @@
+"""Init for womgr custom component."""
+
+DOMAIN = "womgr"

--- a/custom_components/womgr/config_flow.py
+++ b/custom_components/womgr/config_flow.py
@@ -1,0 +1,75 @@
+"""Config flow for womgr integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+
+from . import DOMAIN
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for womgr."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._data: dict[str, Any] = {}
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            self._data.update(user_input)
+            return await self._async_create_entry()
+
+        schema = vol.Schema(
+            {
+                vol.Required("device_name"): str,
+                vol.Required("mac_address"): str,
+                vol.Required("ip_address"): str,
+                vol.Required("os_type"): vol.In(["Windows", "Linux", "macOS", "Other"]),
+                vol.Required("credentials_method"): vol.In(["password", "ssh_key"]),
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def _async_create_entry(self) -> FlowResult:
+        """Create the config entry."""
+        return self.async_create_entry(title=self._data["device_name"], data=self._data)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+
+        class OptionsFlowHandler(config_entries.OptionsFlow):
+            """Handle options."""
+
+            def __init__(self, entry: config_entries.ConfigEntry) -> None:
+                self.entry = entry
+                self._options = dict(entry.data)
+
+            async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+                if user_input is not None:
+                    self._options.update(user_input)
+                    return self.async_create_entry(title="Options", data=self._options)
+
+                schema = vol.Schema(
+                    {
+                        vol.Required(
+                            "credentials_method",
+                            default=self._options.get("credentials_method", "password"),
+                        ): vol.In(["password", "ssh_key"]),
+                    }
+                )
+
+                return self.async_show_form(step_id="init", data_schema=schema)
+
+        return OptionsFlowHandler(config_entry)

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,0 +1,9 @@
+{
+    "domain": "womgr",
+    "name": "WO Manager",
+    "version": "0.0.1",
+    "documentation": "https://example.com/docs",
+    "dependencies": [],
+    "codeowners": [],
+    "config_flow": true
+}


### PR DESCRIPTION
## Summary
- set up basic WO Manager custom component
- implement ConfigFlow for adding devices
- document the new integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847faf0e7f483308ff9630450352f0c