### PR TITLE
Add WoManager dashboard prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-Needs populating
+# WoManager
+
+A minimal Flask-based dashboard to manage Wake-on-LAN capable devices.
+
+## Setup
+
+1. Install dependencies:
+   ```sh
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```sh
+   python wo_manager.py
+   ```
+   This will create a default `WoManager` dashboard if missing and start a web
+   server on port 5000.
+
+## Configuration
+
+Edit `devices.json` to add or remove devices. Each device entry requires a
+`name`, `mac`, and `ip` address.
+
+Example:
+
+```json
+{
+  "devices": [
+    {"name": "Server", "mac": "00:11:22:33:44:55", "ip": "192.168.1.10"}
+  ]
+}
+```
+
+Changes to this file are reflected on the dashboard when the page reloads.
+
+## Usage
+
+The dashboard shows one card per device with buttons to wake, restart or shut
+it down. Device online status is determined using a simple ping check when the
+page loads.
+
+Restart and shutdown actions attempt to run SSH commands on the device and may
+require key-based authentication or additional configuration.

--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,6 @@
+{
+  "devices": [
+    {"name": "Server", "mac": "00:11:22:33:44:55", "ip": "192.168.1.10"},
+    {"name": "Desktop", "mac": "AA:BB:CC:DD:EE:FF", "ip": "192.168.1.20"}
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+wakeonlan

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,4 @@
+body { font-family: sans-serif; padding: 20px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+.card { border: 1px solid #ccc; border-radius: 10px; padding: 1rem; text-align: center; }
+.actions form { display: inline-block; margin: 0 5px; }

--- a/templates/womanager.html
+++ b/templates/womanager.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>WoManager</title>
+    <link rel="stylesheet" href="/static/styles.css">
+  </head>
+  <body>
+    <h1>WoManager Dashboard</h1>
+    <div class="grid">
+      {% for d in devices %}
+      <div class="card">
+        <h2>{{ d.name }}</h2>
+        <p>Status: {% if d.status %}Online{% else %}Offline{% endif %}</p>
+        <div class="actions">
+          <form method="post" action="/wol/{{ d.mac }}">
+            <button type="submit">Wake</button>
+          </form>
+          <form method="post" action="/restart/{{ d.ip }}">
+            <button type="submit">Restart</button>
+          </form>
+          <form method="post" action="/shutdown/{{ d.ip }}">
+            <button type="submit">Shutdown</button>
+          </form>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </body>
+</html>

--- a/wo_manager.py
+++ b/wo_manager.py
@@ -1,0 +1,115 @@
+import os
+import json
+import subprocess
+from flask import Flask, render_template, redirect, url_for, request
+from wakeonlan import send_magic_packet
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_FILE = os.path.join(BASE_DIR, 'templates', 'womanager.html')
+CONFIG_FILE = os.path.join(BASE_DIR, 'devices.json')
+
+app = Flask(__name__)
+
+
+def ensure_dashboard():
+    os.makedirs(os.path.join(BASE_DIR, 'templates'), exist_ok=True)
+    os.makedirs(os.path.join(BASE_DIR, 'static'), exist_ok=True)
+    if not os.path.exists(TEMPLATE_FILE):
+        with open(TEMPLATE_FILE, 'w') as f:
+            f.write("""<!doctype html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>WoManager</title>
+    <link rel='stylesheet' href='/static/styles.css'>
+  </head>
+  <body>
+    <h1>WoManager Dashboard</h1>
+    <div class='grid'>
+      {% for d in devices %}
+      <div class='card'>
+        <h2>{{ d.name }}</h2>
+        <p>Status: {% if d.status %}Online{% else %}Offline{% endif %}</p>
+        <div class='actions'>
+          <form method='post' action='/wol/{{ d.mac }}'><button type='submit'>Wake</button></form>
+          <form method='post' action='/restart/{{ d.ip }}'><button type='submit'>Restart</button></form>
+          <form method='post' action='/shutdown/{{ d.ip }}'><button type='submit'>Shutdown</button></form>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </body>
+</html>""")
+    if not os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, 'w') as f:
+            json.dump({"devices": []}, f)
+
+
+def load_devices():
+    if not os.path.exists(CONFIG_FILE):
+        return []
+    with open(CONFIG_FILE) as f:
+        data = json.load(f)
+    devices = data.get('devices', [])
+    for d in devices:
+        d['status'] = check_status(d.get('ip'))
+    return devices
+
+
+def check_status(ip: str) -> bool:
+    if not ip:
+        return False
+    try:
+        result = subprocess.run(['ping', '-c', '1', '-W', '1', ip], stdout=subprocess.DEVNULL)
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def remote_cmd(ip: str, command: str):
+    try:
+        subprocess.run(['ssh', ip, command], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=5)
+    except Exception as exc:
+        print(f"Failed to run {command} on {ip}: {exc}")
+
+
+def restart_device(ip: str):
+    remote_cmd(ip, 'sudo reboot')
+
+
+def shutdown_device(ip: str):
+    remote_cmd(ip, 'sudo shutdown now')
+
+
+@app.route('/')
+def index():
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/WoManager')
+def dashboard():
+    devices = load_devices()
+    return render_template('womanager.html', devices=devices)
+
+
+@app.route('/wol/<mac>', methods=['POST'])
+def wake(mac):
+    send_magic_packet(mac)
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/restart/<ip>', methods=['POST'])
+def restart(ip):
+    restart_device(ip)
+    return redirect(url_for('dashboard'))
+
+
+@app.route('/shutdown/<ip>', methods=['POST'])
+def shutdown(ip):
+    shutdown_device(ip)
+    return redirect(url_for('dashboard'))
+
+
+if __name__ == '__main__':
+    ensure_dashboard()
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- create minimal Flask app `wo_manager.py`
- add default dashboard template and styles
- provide `devices.json` example and update README
- add dependency list in `requirements.txt`

## Testing
- `python wo_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6847faf263ac83309b540a7d4cf5b864