### PR TITLE
Bump version numbers for HACS

### DIFF
--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "config_flow": true,
     "requirements": []
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "1.2.4"
+  "version": "1.2.5"
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HaWoManager',
-    version='0.0.1',
+    version='0.0.2',
     description='Device management utilities with Home Assistant integration',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Summary
- bump the integration version in `manifest.json`
- bump `setup.py` package version
- update `hacs.json` metadata version

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68487bbc9f3483308fe78705ad4eac80