### PR TITLE
Implement pop-up bubble card layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.5] - 2025-06-12
+### Added
+- Bubble Card pop-up layout for device cards
+
+The release is tagged as `v0.0.5`.
+
 ## [0.0.4] - 2025-06-11
 ### Added
 - Optional initial setup without specifying a device

--- a/README.md
+++ b/README.md
@@ -83,17 +83,29 @@ Copy the `custom_components/womgr` folder into your Home Assistant `config/custo
 Below is a minimal example using the community "Bubble Card".  An example file is provided at `lovelace/womgr_example.yaml`.  Import it into your dashboard or copy the following snippet:
 
 ```yaml
-type: custom:bubble-card
+type: vertical-stack
 title: HaWoManager
 cards:
-  - type: entity
-    entity: binary_sensor.server_ping
-  - type: entity
-    entity: switch.server_wake
-  - type: button
-    entity: button.server_restart
-  - type: button
-    entity: button.server_shutdown
+  - type: custom:bubble-card
+    card_type: pop-up
+    hash: '#server'
+    cards:
+      - type: entity
+        entity: binary_sensor.server_ping
+      - type: entity
+        entity: switch.server_wake
+      - type: button
+        entity: button.server_restart
+      - type: button
+        entity: button.server_shutdown
+  - type: custom:bubble-card
+    card_type: button
+    name: Server
+    icon: mdi:server-network
+    tap_action:
+      action: navigate
+      navigation_path: '#server'
+    show_state: false
 ```
 
 This example assumes the device was added with the name `server`.
@@ -116,4 +128,4 @@ Repeat the command for additional devices. The script appends a card to the
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.3**.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.5**.

--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -57,14 +57,30 @@ async def _async_update_dashboard(hass: HomeAssistant, entry: ConfigEntry) -> No
 
 
     view = next((v for v in config.get("views", []) if v.get("path") == "womgr"), None)
+    hash_tag = f"#womgr-{entry.data['device_name']}"
     card = {
-        "type": "custom:bubble-card",
+        "type": "vertical-stack",
         "title": entry.data["device_name"],
         "cards": [
-            {"type": "entity", "entity": f"binary_sensor.{entry.data['device_name']}_ping"},
-            {"type": "entity", "entity": f"switch.{entry.data['device_name']}_wake"},
-            {"type": "button", "entity": f"button.{entry.data['device_name']}_restart"},
-            {"type": "button", "entity": f"button.{entry.data['device_name']}_shutdown"},
+            {
+                "type": "custom:bubble-card",
+                "card_type": "pop-up",
+                "hash": hash_tag,
+                "cards": [
+                    {"type": "entity", "entity": f"binary_sensor.{entry.data['device_name']}_ping"},
+                    {"type": "entity", "entity": f"switch.{entry.data['device_name']}_wake"},
+                    {"type": "button", "entity": f"button.{entry.data['device_name']}_restart"},
+                    {"type": "button", "entity": f"button.{entry.data['device_name']}_shutdown"},
+                ],
+            },
+            {
+                "type": "custom:bubble-card",
+                "card_type": "button",
+                "name": entry.data["device_name"],
+                "icon": "mdi:server-network",
+                "tap_action": {"action": "navigate", "navigation_path": hash_tag},
+                "show_state": False,
+            },
         ],
     }
 

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "config_flow": true,
     "requirements": []
 }

--- a/dashboard_cli.py
+++ b/dashboard_cli.py
@@ -11,14 +11,30 @@ def create_dashboard(url: str, token: str, device_name: str):
     config = resp.json()
 
     view = next((v for v in config.get("views", []) if v.get("path") == "womgr"), None)
+    hash_tag = f"#womgr-{device_name}"
     card = {
-        "type": "custom:bubble-card",
-        "title": "HaWoManager",
+        "type": "vertical-stack",
+        "title": device_name,
         "cards": [
-            {"type": "entity", "entity": f"binary_sensor.{device_name}_ping"},
-            {"type": "entity", "entity": f"switch.{device_name}_wake"},
-            {"type": "button", "entity": f"button.{device_name}_restart"},
-            {"type": "button", "entity": f"button.{device_name}_shutdown"},
+            {
+                "type": "custom:bubble-card",
+                "card_type": "pop-up",
+                "hash": hash_tag,
+                "cards": [
+                    {"type": "entity", "entity": f"binary_sensor.{device_name}_ping"},
+                    {"type": "entity", "entity": f"switch.{device_name}_wake"},
+                    {"type": "button", "entity": f"button.{device_name}_restart"},
+                    {"type": "button", "entity": f"button.{device_name}_shutdown"},
+                ],
+            },
+            {
+                "type": "custom:bubble-card",
+                "card_type": "button",
+                "name": device_name,
+                "icon": "mdi:server-network",
+                "tap_action": {"action": "navigate", "navigation_path": hash_tag},
+                "show_state": False,
+            },
         ],
     }
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/lovelace/womgr_example.yaml
+++ b/lovelace/womgr_example.yaml
@@ -1,11 +1,23 @@
-type: custom:bubble-card
+type: vertical-stack
 title: HaWoManager
 cards:
-  - type: entity
-    entity: binary_sensor.server_ping
-  - type: entity
-    entity: switch.server_wake
-  - type: button
-    entity: button.server_restart
-  - type: button
-    entity: button.server_shutdown
+  - type: custom:bubble-card
+    card_type: pop-up
+    hash: '#server'
+    cards:
+      - type: entity
+        entity: binary_sensor.server_ping
+      - type: entity
+        entity: switch.server_wake
+      - type: button
+        entity: button.server_restart
+      - type: button
+        entity: button.server_shutdown
+  - type: custom:bubble-card
+    card_type: button
+    name: Server
+    icon: mdi:server-network
+    tap_action:
+      action: navigate
+      navigation_path: '#server'
+    show_state: false

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HaWoManager',
-    version='0.0.4',
+    version='0.0.5',
     description='Device management utilities with Home Assistant integration',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Summary
- add pop-up bubble card layout for devices
- update dashboard CLI
- refresh Lovelace example
- bump version to 0.0.5 and document changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848db2f49708330bc8639955f767112