### PR TITLE
Fix util import for Home Assistant integration

### DIFF
--- a/custom_components/womgr/config_flow.py
+++ b/custom_components/womgr/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
-from womgr.util import parse_mac_address
+from .util import parse_mac_address
 
 from .const import DOMAIN
 

--- a/custom_components/womgr/core/entities.py
+++ b/custom_components/womgr/core/entities.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from typing import List
 
-from womgr.util import parse_mac_address
+from ..util import parse_mac_address
 
 
 def _create_entity_id(device_name: str, entity: str) -> str:

--- a/custom_components/womgr/util.py
+++ b/custom_components/womgr/util.py
@@ -1,0 +1,22 @@
+"""Helper functions for the WoMgr integration."""
+
+from __future__ import annotations
+
+
+def parse_mac_address(mac: str) -> bytes:
+    """Convert a MAC address string to bytes.
+
+    Separators ``:`` or ``-`` are allowed and surrounding whitespace is
+    ignored.  The resulting string must contain exactly 12 hexadecimal
+    characters. ``ValueError`` is raised if validation fails.
+    """
+
+    cleaned = mac.replace(":", "").replace("-", "").strip()
+    if len(cleaned) != 12:
+        raise ValueError("Invalid MAC address")
+
+    try:
+        return bytes.fromhex(cleaned)
+    except ValueError as exc:
+        raise ValueError("Invalid MAC address") from exc
+


### PR DESCRIPTION
## Summary
- include helper util in the custom component
- use relative imports for `parse_mac_address`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848df343b3483309290040c6402cc5d