### PR TITLE
Fix unload failure when no device configured

### DIFF
--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -145,7 +145,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a WoMgr config entry."""
-    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if entry.data:
+        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     config = hass.data[DOMAIN].pop(entry.entry_id, None)
     if config:
         remove_device(config)

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,65 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+# Stub minimal homeassistant modules required for import
+ha = types.ModuleType("homeassistant")
+ha.config_entries = types.ModuleType("config_entries")
+ha.config_entries.ConfigEntry = object
+ha.core = types.ModuleType("core")
+ha.core.HomeAssistant = object
+ha.helpers = types.ModuleType("helpers")
+ha.helpers.typing = types.ModuleType("typing")
+ha.helpers.typing.ConfigType = dict
+ha.components = types.ModuleType("components")
+lovelace = types.ModuleType("lovelace")
+lovelace.const = types.SimpleNamespace(
+    CONF_ALLOW_SINGLE_WORD="allow_single_word",
+    CONF_ICON="icon",
+    CONF_TITLE="title",
+    CONF_URL_PATH="url_path",
+)
+
+class DummyDashboardsCollection:
+    pass
+
+class DummyLovelaceStorage:
+    async def async_load(self, *args, **kwargs):
+        raise Exception
+    async def async_save(self, *args, **kwargs):
+        pass
+
+class ConfigNotFound(Exception):
+    pass
+
+lovelace.dashboard = types.SimpleNamespace(
+    DashboardsCollection=DummyDashboardsCollection,
+    LovelaceStorage=DummyLovelaceStorage,
+    ConfigNotFound=ConfigNotFound,
+)
+
+ha.components.lovelace = lovelace
+
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
+sys.modules.setdefault("homeassistant.core", ha.core)
+sys.modules.setdefault("homeassistant.helpers", ha.helpers)
+sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
+sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
+sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
+sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)
+
+from custom_components.womgr import async_unload_entry
+from custom_components.womgr.const import DOMAIN
+
+class DummyConfigEntries:
+    async def async_unload_platforms(self, entry, platforms):
+        raise AssertionError("unload should not be called")
+
+def test_unload_entry_without_data():
+    hass = SimpleNamespace(data={DOMAIN: {}}, config_entries=DummyConfigEntries())
+    entry = SimpleNamespace(data={}, entry_id="dummy")
+    assert asyncio.run(async_unload_entry(hass, entry))
+


### PR DESCRIPTION
## Summary
- avoid unloading platforms when the config entry has no data
- add regression test covering the unload scenario

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e419a97083308a8377cc83310eee