### PR TITLE
Fix WoMgr button initialization

### DIFF
--- a/custom_components/womgr/button.py
+++ b/custom_components/womgr/button.py
@@ -27,10 +27,16 @@ class _SystemButton(ButtonEntity):
 
 
 class WoMgrRestartButton(_SystemButton):
+    def __init__(self, system: SystemCommandSwitch) -> None:
+        super().__init__(system, "restart")
+
     async def async_press(self) -> None:
         await self.hass.async_add_executor_job(self._system.restart)
 
 
 class WoMgrShutdownButton(_SystemButton):
+    def __init__(self, system: SystemCommandSwitch) -> None:
+        super().__init__(system, "shutdown")
+
     async def async_press(self) -> None:
         await self.hass.async_add_executor_job(self._system.shutdown)


### PR DESCRIPTION
## Summary
- ensure restart and shutdown buttons pass the action when initializing `_SystemButton`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e432eac48330969c0a9e7c7ad6e6