### PR TITLE
Fix lovelace property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.6] - 2025-06-13
+### Fixed
+- Use lovelace property access for Home Assistant 2026.2 compatibility
+
+The release is tagged as `v0.0.6`.
+
 ## [0.0.5] - 2025-06-12
 ### Added
 - Bubble Card pop-up layout for device cards

--- a/README.md
+++ b/README.md
@@ -128,4 +128,4 @@ Repeat the command for additional devices. The script appends a card to the
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.5**.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.6**.

--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -32,8 +32,10 @@ async def _async_update_dashboard(hass: HomeAssistant, entry: ConfigEntry) -> No
     if not lovelace:
         return
 
-    dashboards: dict = lovelace.get("dashboards", {})
-    dashboards_collection: DashboardsCollection = lovelace.get("dashboards_collection")
+    dashboards: dict = getattr(lovelace, "dashboards", lovelace.get("dashboards", {}))
+    dashboards_collection: DashboardsCollection = getattr(
+        lovelace, "dashboards_collection", lovelace.get("dashboards_collection")
+    )
 
     if dashboards_collection is None:
         return
@@ -103,7 +105,7 @@ async def _async_remove_dashboard_card(hass: HomeAssistant, entry: ConfigEntry) 
     if not lovelace:
         return
 
-    dashboards: dict = lovelace.get("dashboards", {})
+    dashboards: dict = getattr(lovelace, "dashboards", lovelace.get("dashboards", {}))
     if "womgr" not in dashboards:
         return
 

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "config_flow": true,
     "requirements": []
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HaWoManager',
-    version='0.0.5',
+    version='0.0.6',
     description='Device management utilities with Home Assistant integration',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Summary
- access lovelace dashboards via properties
- bump version to 0.0.6
- update changelog and documentation

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e436a6188330bf7c596264d02a99