### PR TITLE
Improve MAC address validation

### DIFF
--- a/custom_components/womgr/util.py
+++ b/custom_components/womgr/util.py
@@ -2,21 +2,6 @@
 
 from __future__ import annotations
 
+from womgr.util import parse_mac_address
 
-def parse_mac_address(mac: str) -> bytes:
-    """Convert a MAC address string to bytes.
-
-    Separators ``:`` or ``-`` are allowed and surrounding whitespace is
-    ignored.  The resulting string must contain exactly 12 hexadecimal
-    characters. ``ValueError`` is raised if validation fails.
-    """
-
-    cleaned = mac.replace(":", "").replace("-", "").strip()
-    if len(cleaned) != 12:
-        raise ValueError("Invalid MAC address")
-
-    try:
-        return bytes.fromhex(cleaned)
-    except ValueError as exc:
-        raise ValueError("Invalid MAC address") from exc
-
+__all__ = ["parse_mac_address"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,14 +4,19 @@ from womgr.util import parse_mac_address
 
 class TestParseMacAddress(unittest.TestCase):
     def test_valid_mac(self):
-        self.assertEqual(
-            parse_mac_address("AA:BB:CC:DD:EE:FF"),
-            bytes.fromhex("aabbccddeeff"),
-        )
-        self.assertEqual(
-            parse_mac_address("aa-bb-cc-dd-ee-ff"),
-            bytes.fromhex("aabbccddeeff"),
-        )
+        valid_cases = [
+            "AA:BB:CC:DD:EE:FF",
+            "aa:bb:cc:dd:ee:ff",
+            "AA-BB-CC-DD-EE-FF",
+            "aa-bb-cc-dd-ee-ff",
+            "AA-BB:CC-DD:EE-FF",
+        ]
+        for mac in valid_cases:
+            with self.subTest(mac=mac):
+                self.assertEqual(
+                    parse_mac_address(mac),
+                    bytes.fromhex("aabbccddeeff"),
+                )
 
     def test_invalid_mac(self):
         with self.assertRaises(ValueError):

--- a/womgr/util.py
+++ b/womgr/util.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+import re
+
+
+_MAC_RE = re.compile(r"^[0-9A-Fa-f]{2}([:-]?[0-9A-Fa-f]{2}){5}$")
+
 
 def parse_mac_address(mac: str) -> bytes:
     """Convert a MAC address string to bytes.
 
-    Separators ``:`` or ``-`` are allowed. Whitespace is ignored. The
-    resulting string must contain exactly 12 hexadecimal characters.
-    ``ValueError`` is raised if validation fails.
+    Separators ``:`` or ``-`` are allowed. Whitespace surrounding the
+    address is ignored. The resulting string must contain exactly 12
+    hexadecimal characters. ``ValueError`` is raised if validation fails.
     """
-    cleaned = mac.replace(':', '').replace('-', '').strip()
-    if len(cleaned) != 12:
+
+    cleaned = mac.strip()
+    if not _MAC_RE.fullmatch(cleaned):
         raise ValueError("Invalid MAC address")
+
+    cleaned = cleaned.replace(":", "").replace("-", "")
+
     try:
         return bytes.fromhex(cleaned)
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- centralize parse_mac_address in `womgr.util` and re-export for HA integration
- validate MAC addresses with a regex before conversion
- extend util unit tests to cover mixed separators and case variants

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e71e44d8833083c007e323dd79b0