### PR TITLE
Async ping binary sensor

### DIFF
--- a/custom_components/womgr/binary_sensor.py
+++ b/custom_components/womgr/binary_sensor.py
@@ -23,7 +23,7 @@ class WoMgrPingBinarySensor(BinarySensorEntity):
         self._attr_name = f"{sensor.device_name} Ping"
 
     async def async_update(self) -> None:
-        await self.hass.async_add_executor_job(self._sensor.update)
+        await self._sensor.update()
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/womgr/core/entities.py
+++ b/custom_components/womgr/core/entities.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+import asyncio
 import socket
 import subprocess
 import sys
@@ -65,14 +66,27 @@ class PingBinarySensor(WoMgrEntity):
         self.ip = ip
         self.is_on = False
 
-    def update(self) -> bool:
-        args = ["ping"]
+    def _build_ping_args(self) -> list[str]:
+        ping_bin = shutil.which("ping") or "ping"
+        args = [ping_bin]
         if sys.platform.startswith("win"):
             args += ["-n", "1", "-w", "1000", self.ip]
         else:
             args += ["-c", "1", "-W", "1", self.ip]
-        result = subprocess.run(args, stdout=subprocess.DEVNULL)
-        self.is_on = result.returncode == 0
+        return args
+
+    async def update(self) -> bool:
+        args = self._build_ping_args()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.communicate()
+            self.is_on = proc.returncode == 0
+        except FileNotFoundError:
+            self.is_on = False
         return self.is_on
 
 

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+import sys
+
+from womgr.entities import PingBinarySensor
+
+
+class TestPingArgs(unittest.TestCase):
+    def test_linux_args(self):
+        sensor = PingBinarySensor("dev", "1.2.3.4")
+        with patch("shutil.which", return_value="ping"):
+            original = sys.platform
+            sys.platform = "linux"
+            try:
+                args = sensor._build_ping_args()
+            finally:
+                sys.platform = original
+        self.assertEqual(args, ["ping", "-c", "1", "-W", "1", "1.2.3.4"])
+
+    def test_windows_args(self):
+        sensor = PingBinarySensor("dev", "1.2.3.4")
+        with patch("shutil.which", return_value="ping.exe"):
+            original = sys.platform
+            sys.platform = "win32"
+            try:
+                args = sensor._build_ping_args()
+            finally:
+                sys.platform = original
+        self.assertEqual(args, ["ping.exe", "-n", "1", "-w", "1000", "1.2.3.4"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/womgr/entities.py
+++ b/womgr/entities.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+import asyncio
 import socket
 import subprocess
 import sys
@@ -65,14 +66,27 @@ class PingBinarySensor(WoMgrEntity):
         self.ip = ip
         self.is_on = False
 
-    def update(self) -> bool:
-        args = ["ping"]
+    def _build_ping_args(self) -> list[str]:
+        ping_bin = shutil.which("ping") or "ping"
+        args = [ping_bin]
         if sys.platform.startswith("win"):
             args += ["-n", "1", "-w", "1000", self.ip]
         else:
             args += ["-c", "1", "-W", "1", self.ip]
-        result = subprocess.run(args, stdout=subprocess.DEVNULL)
-        self.is_on = result.returncode == 0
+        return args
+
+    async def update(self) -> bool:
+        args = self._build_ping_args()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await proc.communicate()
+            self.is_on = proc.returncode == 0
+        except FileNotFoundError:
+            self.is_on = False
         return self.is_on
 
 

--- a/womgr_cli.py
+++ b/womgr_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 from womgr import (
     setup_device,
     WakeOnLanSwitch,
@@ -60,7 +61,7 @@ def main() -> None:
             print(str(exc))
             return
     elif args.command == "ping":
-        success = ping.update()
+        success = asyncio.run(ping.update())
         print("Device is reachable" if success else "Device is not reachable")
     elif args.command == "restart":
         system.restart()


### PR DESCRIPTION
## Summary
- avoid blocking by using asyncio for ping
- catch `FileNotFoundError`
- test ping argument generation on Linux and Windows

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e727ca2c8330858f4187f5357e7e