### PR TITLE
Add status command and improve CLI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,15 @@ python womgr_cli.py DEVICE_NAME AA:BB:CC:DD:EE:FF 192.0.2.10 Office linux ping
 ```
 The command arguments are `DEVICE_NAME` `MAC` `IP` `LOCATION` `OS_TYPE` and the desired action.
 
-The last argument chooses the action: `wol`, `ping`, `restart`, or `shutdown`.
-Credentials for system commands can be provided with `--username` and
+The last argument chooses the action: `wol`, `ping`, `restart`, `shutdown`, or
+`status`. Credentials for system commands can be provided with `--username` and
 `--password` options. The ping command automatically adjusts parameters for Windows or Linux hosts.
+
+Example to check both reachability and command availability:
+
+```bash
+python womgr_cli.py DEVICE_NAME AA:BB:CC:DD:EE:FF 192.0.2.10 Office linux status
+```
 
 ## Home Assistant Integration
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,65 @@
+import io
+import types
+import sys
+from unittest import TestCase
+from unittest.mock import patch
+
+import womgr_cli
+
+class CLITest(TestCase):
+    def run_cli(self, args, ping_return=0, which_map=None):
+        if which_map is None:
+            which_map = {"reboot": "/sbin/reboot", "shutdown": "/sbin/shutdown"}
+
+        def fake_run(cmd, stdout=None):
+            return types.SimpleNamespace(returncode=ping_return)
+
+        def fake_which(cmd):
+            return which_map.get(cmd)
+
+        out = io.StringIO()
+        with (
+            patch.object(sys, "argv", ["womgr_cli.py"] + args),
+            patch("womgr.entities.subprocess.run", side_effect=fake_run),
+            patch("womgr.entities.shutil.which", side_effect=fake_which),
+            patch("womgr.entities.subprocess.Popen"),
+            patch("sys.stdout", new=out),
+        ):
+            womgr_cli.main()
+        return out.getvalue()
+
+    def test_status_success(self):
+        output = self.run_cli([
+            "server",
+            "00:11:22:33:44:55",
+            "1.2.3.4",
+            "Office",
+            "linux",
+            "status",
+        ])
+        assert "Device is reachable" in output
+        assert "Restart available: True" in output
+        assert "Shutdown available: True" in output
+
+    def test_invalid_os(self):
+        output = self.run_cli([
+            "server",
+            "00:11:22:33:44:55",
+            "1.2.3.4",
+            "Office",
+            "foo",
+            "ping",
+        ])
+        assert "Invalid OS type" in output
+
+    def test_restart_missing_command(self):
+        output = self.run_cli([
+            "server",
+            "00:11:22:33:44:55",
+            "1.2.3.4",
+            "Office",
+            "linux",
+            "restart",
+        ], which_map={"shutdown": "/sbin/shutdown"})
+        assert "reboot command not found" in output
+

--- a/womgr_cli.py
+++ b/womgr_cli.py
@@ -30,6 +30,9 @@ def main() -> None:
     subparsers.add_parser("ping", help="Ping the device")
     subparsers.add_parser("restart", help="Restart the device")
     subparsers.add_parser("shutdown", help="Shut down the device")
+    subparsers.add_parser(
+        "status", help="Check ping and system command availability"
+    )
 
     args = parser.parse_args()
 
@@ -37,6 +40,10 @@ def main() -> None:
         parse_mac_address(args.mac)
     except ValueError:
         print("Invalid MAC address")
+        return
+
+    if args.os_type.lower() not in {"linux", "windows"}:
+        print(f"Invalid OS type: {args.os_type}. Choose 'linux' or 'windows'.")
         return
 
     entry = setup_device(
@@ -63,9 +70,25 @@ def main() -> None:
         success = ping.update()
         print("Device is reachable" if success else "Device is not reachable")
     elif args.command == "restart":
-        system.restart()
+        try:
+            system.restart()
+        except (FileNotFoundError, ValueError) as exc:
+            print(str(exc))
     elif args.command == "shutdown":
-        system.shutdown()
+        try:
+            system.shutdown()
+        except (FileNotFoundError, ValueError) as exc:
+            print(str(exc))
+    elif args.command == "status":
+        success = ping.update()
+        print("Device is reachable" if success else "Device is not reachable")
+        try:
+            availability = system.available_commands()
+            print(
+                f"Restart available: {availability['restart']}\nShutdown available: {availability['shutdown']}"
+            )
+        except ValueError as exc:
+            print(str(exc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `status` command for CLI
- provide clearer error handling for invalid OS types and missing commands
- document new usage in README
- add CLI tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e73afdb88330be2b716f62b7515d