### PR TITLE
Improve dashboard CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project will be documented in this file.
 
 The release is tagged as `v0.0.6`.
 
+## [0.0.7] - 2025-06-14
+### Added
+- Token can be provided via `HASS_TOKEN` environment variable
+- Optional `--path` for custom dashboard URL
+### Changed
+- Requests to Home Assistant API show friendly error messages
+
+The release is tagged as `v0.0.7`.
+
 ## [0.0.5] - 2025-06-12
 ### Added
 - Bubble Card pop-up layout for device cards

--- a/README.md
+++ b/README.md
@@ -120,12 +120,16 @@ create the view and insert the card.  Provide your Home Assistant URL and a
 long-lived access token:
 
 ```bash
-python dashboard_cli.py http://homeassistant.local:8123 YOUR_TOKEN server
+# pass the token via an environment variable or --token
+HASS_TOKEN=YOUR_TOKEN python dashboard_cli.py http://homeassistant.local:8123 server
 ```
+
+Specify a custom dashboard URL path with `--path` if you don't want to use the
+default `womgr` path.
 
 Repeat the command for additional devices. The script appends a card to the
 `HaWoManager` view each time it runs.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.6**.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.7**.

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "config_flow": true,
     "requirements": []
 }

--- a/dashboard_cli.py
+++ b/dashboard_cli.py
@@ -1,17 +1,24 @@
 import argparse
 import json
+import os
 import requests
+from requests import RequestException
 
 
-def create_dashboard(url: str, token: str, device_name: str):
+def create_dashboard(
+    url: str, token: str, device_name: str, path: str = "womgr"
+) -> None:
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    # Fetch existing Lovelace config
-    resp = requests.get(f"{url}/api/lovelace/config", headers=headers, timeout=10)
-    resp.raise_for_status()
-    config = resp.json()
+    try:
+        resp = requests.get(f"{url}/api/lovelace/config", headers=headers, timeout=10)
+        resp.raise_for_status()
+        config = resp.json()
+    except RequestException as exc:
+        print(f"Failed to fetch Lovelace config: {exc}")
+        return
 
-    view = next((v for v in config.get("views", []) if v.get("path") == "womgr"), None)
-    hash_tag = f"#womgr-{device_name}"
+    view = next((v for v in config.get("views", []) if v.get("path") == path), None)
+    hash_tag = f"#{path}-{device_name}"
     card = {
         "type": "vertical-stack",
         "title": device_name,
@@ -39,28 +46,45 @@ def create_dashboard(url: str, token: str, device_name: str):
     }
 
     if view is None:
-        view = {"path": "womgr", "title": "HaWoManager", "cards": [card]}
+        view = {"path": path, "title": "HaWoManager", "cards": [card]}
         config.setdefault("views", []).append(view)
     else:
         view.setdefault("cards", []).append(card)
 
-    resp = requests.post(
-        f"{url}/api/lovelace/config",
-        headers=headers,
-        data=json.dumps(config),
-        timeout=10,
-    )
-    resp.raise_for_status()
+    try:
+        resp = requests.post(
+            f"{url}/api/lovelace/config",
+            headers=headers,
+            data=json.dumps(config),
+            timeout=10,
+        )
+        resp.raise_for_status()
+    except RequestException as exc:
+        print(f"Failed to update Lovelace config: {exc}")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Create HaWoManager dashboard")
     parser.add_argument("url", help="Base URL of Home Assistant, e.g. http://hass:8123")
-    parser.add_argument("token", help="Long-Lived Access Token")
     parser.add_argument("device_name", help="Device name used in HaWoManager")
+    parser.add_argument(
+        "--token",
+        help="Long-Lived Access Token; falls back to HASS_TOKEN environment variable",
+    )
+    parser.add_argument(
+        "--path",
+        default="womgr",
+        help="Dashboard URL path to use (default: womgr)",
+    )
     args = parser.parse_args()
 
-    create_dashboard(args.url, args.token, args.device_name)
+    token = args.token or os.environ.get("HASS_TOKEN")
+    if not token:
+        parser.error(
+            "Token must be provided via --token or HASS_TOKEN environment variable"
+        )
+
+    create_dashboard(args.url, token, args.device_name, args.path)
 
 
 if __name__ == "__main__":

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HaWoManager',
-    version='0.0.6',
+    version='0.0.7',
     description='Device management utilities with Home Assistant integration',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Summary
- add friendly error messages for REST calls
- support env var token and custom dashboard path
- bump version to 0.0.7

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e73f5e608330aa89ed0211fb0387