### PR TITLE
Improve config flow validation

### DIFF
--- a/custom_components/womgr/config_flow.py
+++ b/custom_components/womgr/config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ipaddress import ip_address
+
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -44,6 +46,20 @@ class WoMgrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 parse_mac_address(user_input["mac"])
             except ValueError:
                 errors["mac"] = "invalid_mac"
+
+            try:
+                ip_address(user_input["ip"])
+            except ValueError:
+                errors["ip"] = "invalid_ip"
+
+            if not errors:
+                for entry in self._async_current_entries():
+                    if not entry.data:
+                        continue
+                    if entry.data.get("device_name") == user_input["device_name"]:
+                        return self.async_abort(reason="duplicate_device_name")
+                    if entry.data.get("mac") == user_input["mac"]:
+                        return self.async_abort(reason="duplicate_mac")
 
             if not errors:
                 return self.async_create_entry(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,105 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+# Stub minimal homeassistant modules required for import
+ha = types.ModuleType("homeassistant")
+ha.config_entries = types.ModuleType("config_entries")
+ha.config_entries.ConfigEntry = object
+class DummyConfigFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+    def async_show_form(self, *, step_id: str, data_schema=None, errors=None):
+        return {"type": "form", "step_id": step_id, "errors": errors or {}}
+
+    def async_create_entry(self, *, title: str, data: dict):
+        return {"type": "create_entry", "title": title, "data": data}
+
+    def async_abort(self, **kwargs):
+        return {"type": "abort", **kwargs}
+
+ha.config_entries.ConfigFlow = DummyConfigFlow
+ha.core = types.ModuleType("core")
+ha.core.HomeAssistant = object
+ha.helpers = types.ModuleType("helpers")
+ha.helpers.typing = types.ModuleType("typing")
+ha.helpers.typing.ConfigType = dict
+ha.components = types.ModuleType("components")
+lovelace = types.ModuleType("lovelace")
+lovelace.const = types.SimpleNamespace(
+    CONF_ALLOW_SINGLE_WORD="allow_single_word",
+    CONF_ICON="icon",
+    CONF_TITLE="title",
+    CONF_URL_PATH="url_path",
+)
+
+class DummyDashboardsCollection:
+    pass
+
+class DummyLovelaceStorage:
+    async def async_load(self, *args, **kwargs):
+        raise Exception
+    async def async_save(self, *args, **kwargs):
+        pass
+
+class ConfigNotFound(Exception):
+    pass
+
+lovelace.dashboard = types.SimpleNamespace(
+    DashboardsCollection=DummyDashboardsCollection,
+    LovelaceStorage=DummyLovelaceStorage,
+    ConfigNotFound=ConfigNotFound,
+)
+ha.components.lovelace = lovelace
+
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
+sys.modules.setdefault("homeassistant.core", ha.core)
+sys.modules.setdefault("homeassistant.helpers", ha.helpers)
+sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
+sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
+sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
+sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)
+
+import unittest
+from custom_components.womgr.config_flow import WoMgrConfigFlow
+
+
+def _valid_input(**overrides):
+    data = {
+        "device_name": "dev1",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "ip": "192.168.1.100",
+        "location": "lab",
+        "os_type": "linux",
+        "username": "",
+        "password": "",
+    }
+    data.update(overrides)
+    return data
+
+
+class TestConfigFlow(unittest.TestCase):
+    def test_step_device_invalid_ip(self):
+        flow = WoMgrConfigFlow()
+        result = asyncio.run(flow.async_step_device(_valid_input(ip="invalid")))
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["errors"], {"ip": "invalid_ip"})
+
+    def test_step_device_duplicate_device_name(self):
+        flow = WoMgrConfigFlow()
+        flow._async_current_entries = lambda: [SimpleNamespace(data=_valid_input())]
+        result = asyncio.run(flow.async_step_device(_valid_input()))
+        self.assertEqual(result["type"], "abort")
+        self.assertEqual(result["reason"], "duplicate_device_name")
+
+    def test_step_device_duplicate_mac(self):
+        flow = WoMgrConfigFlow()
+        flow._async_current_entries = lambda: [SimpleNamespace(data=_valid_input())]
+        result = asyncio.run(flow.async_step_device(_valid_input(device_name="dev2")))
+        self.assertEqual(result["type"], "abort")
+        self.assertEqual(result["reason"], "duplicate_mac")
+


### PR DESCRIPTION
## Summary
- validate IP addresses during config flow
- detect duplicate device_name or MAC entries
- add unit tests for invalid IP and duplicate detection

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6848e7431c4c8330b83446b75524b263