### PR TITLE
Add missing unit tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,88 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import womgr_cli
+import dashboard_cli
+
+
+def test_womgr_cli_invalid_mac(capsys):
+    args = [
+        "womgr_cli",
+        "pc",
+        "invalid",
+        "1.2.3.4",
+        "lab",
+        "linux",
+        "wol",
+    ]
+    with patch.object(sys, "argv", args), patch("womgr_cli.setup_device") as setup:
+        womgr_cli.main()
+        setup.assert_not_called()
+    out = capsys.readouterr().out
+    assert "Invalid MAC address" in out
+
+
+def test_womgr_cli_parsing_calls_correct_command():
+    class DummyWOL:
+        def __init__(self):
+            self.called = False
+
+        def turn_on(self):
+            self.called = True
+
+    class DummyPing:
+        def __init__(self):
+            self.called = False
+
+        def update(self):
+            self.called = True
+
+    class DummySystem:
+        def restart(self):
+            pass
+
+        def shutdown(self):
+            pass
+
+    entry = SimpleNamespace(entities=[DummyWOL(), DummyPing(), DummySystem()])
+
+    args = [
+        "womgr_cli",
+        "pc",
+        "AA:BB:CC:DD:EE:FF",
+        "1.2.3.4",
+        "lab",
+        "linux",
+        "ping",
+    ]
+    with patch.object(sys, "argv", args), \
+         patch("womgr_cli.setup_device", return_value=entry), \
+         patch("womgr_cli.WakeOnLanSwitch", DummyWOL), \
+         patch("womgr_cli.PingBinarySensor", DummyPing), \
+         patch("womgr_cli.SystemCommandSwitch", DummySystem):
+        womgr_cli.main()
+
+    assert entry.entities[1].called
+    
+
+def test_dashboard_cli_main_parsing():
+    args = ["dashboard_cli", "http://hass", "token", "pc"]
+    with patch.object(sys, "argv", args), patch(
+        "dashboard_cli.create_dashboard"
+    ) as create:
+        dashboard_cli.main()
+        create.assert_called_once_with("http://hass", "token", "pc")
+
+
+@patch("dashboard_cli.requests.get")
+@patch("dashboard_cli.requests.post")
+def test_create_dashboard_http_error(mock_post, mock_get):
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = requests.HTTPError
+    mock_get.return_value = resp
+    with pytest.raises(requests.HTTPError):
+        dashboard_cli.create_dashboard("http://hass", "token", "pc")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,97 @@
+import asyncio
+import sys
+import types
+
+# Stub minimal homeassistant modules required for import
+ha = types.ModuleType("homeassistant")
+ha.config_entries = types.ModuleType("config_entries")
+class DummyConfigFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+ha.config_entries.ConfigEntry = object
+ha.config_entries.ConfigFlow = DummyConfigFlow
+ha.core = types.ModuleType("core")
+ha.core.HomeAssistant = object
+ha.helpers = types.ModuleType("helpers")
+ha.helpers.typing = types.ModuleType("typing")
+ha.helpers.typing.ConfigType = dict
+ha.components = types.ModuleType("components")
+lovelace = types.ModuleType("lovelace")
+lovelace.const = types.SimpleNamespace(
+    CONF_ALLOW_SINGLE_WORD="allow_single_word",
+    CONF_ICON="icon",
+    CONF_TITLE="title",
+    CONF_URL_PATH="url_path",
+)
+
+class DummyDashboardsCollection:
+    pass
+
+class DummyLovelaceStorage:
+    async def async_load(self, *args, **kwargs):
+        return {"views": []}
+    async def async_save(self, *args, **kwargs):
+        pass
+
+class ConfigNotFound(Exception):
+    pass
+
+lovelace.dashboard = types.SimpleNamespace(
+    DashboardsCollection=DummyDashboardsCollection,
+    LovelaceStorage=DummyLovelaceStorage,
+    ConfigNotFound=ConfigNotFound,
+)
+
+ha.components.lovelace = lovelace
+
+sys.modules.setdefault("homeassistant", ha)
+sys.modules.setdefault("homeassistant.config_entries", ha.config_entries)
+sys.modules.setdefault("homeassistant.core", ha.core)
+sys.modules.setdefault("homeassistant.helpers", ha.helpers)
+sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
+sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
+sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
+sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)
+
+from custom_components.womgr.config_flow import WoMgrConfigFlow
+
+
+async def run_step(input_data):
+    flow = WoMgrConfigFlow()
+
+    def async_show_form(*args, **kwargs):
+        return {"type": "form", "errors": kwargs.get("errors")}
+
+    def async_create_entry(*args, **kwargs):
+        return {"type": "create_entry", "data": kwargs.get("data")}
+
+    flow.async_show_form = async_show_form
+    flow.async_create_entry = async_create_entry
+    return await flow.async_step_device(input_data)
+
+
+def test_config_flow_mac_validation_error():
+    invalid = {
+        "device_name": "pc",
+        "mac": "invalid",
+        "ip": "1.2.3.4",
+        "location": "lab",
+        "os_type": "linux",
+    }
+    result = asyncio.run(run_step(invalid))
+    assert result["type"] == "form"
+    assert result["errors"] == {"mac": "invalid_mac"}
+
+
+def test_config_flow_valid_device():
+    valid = {
+        "device_name": "pc",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "ip": "1.2.3.4",
+        "location": "lab",
+        "os_type": "linux",
+    }
+    result = asyncio.run(run_step(valid))
+    assert result["type"] == "create_entry"
+    assert result["data"] == valid

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,82 @@
+import socket
+import subprocess
+from unittest.mock import patch
+
+from womgr.entities import (
+    WakeOnLanSwitch,
+    PingBinarySensor,
+    SystemCommandSwitch,
+)
+
+
+@patch("womgr.entities.socket.socket")
+def test_wake_on_lan_turn_on(mock_socket):
+    sock = mock_socket.return_value.__enter__.return_value
+    switch = WakeOnLanSwitch("pc", "AA:BB:CC:DD:EE:FF")
+    switch.turn_on()
+    packet = b"\xff" * 6 + bytes.fromhex("aabbccddeeff") * 16
+    mock_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt.assert_called_once_with(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.sendto.assert_called_once_with(packet, ("<broadcast>", 9))
+
+
+@patch("womgr.entities.subprocess.run")
+def test_ping_update_linux(mock_run):
+    mock_run.return_value.returncode = 0
+    sensor = PingBinarySensor("pc", "1.2.3.4")
+    with patch("womgr.entities.sys.platform", "linux"):
+        assert sensor.update() is True
+    mock_run.assert_called_once_with(
+        ["ping", "-c", "1", "-W", "1", "1.2.3.4"], stdout=subprocess.DEVNULL
+    )
+
+
+@patch("womgr.entities.subprocess.run")
+def test_ping_update_windows(mock_run):
+    mock_run.return_value.returncode = 1
+    sensor = PingBinarySensor("pc", "1.2.3.4")
+    with patch("womgr.entities.sys.platform", "win32"):
+        assert sensor.update() is False
+    mock_run.assert_called_once_with(
+        ["ping", "-n", "1", "-w", "1000", "1.2.3.4"], stdout=subprocess.DEVNULL
+    )
+
+
+@patch("womgr.entities.subprocess.Popen")
+@patch("womgr.entities.shutil.which")
+def test_system_command_restart_linux(mock_which, mock_popen):
+    mock_which.side_effect = lambda cmd: f"/usr/bin/{cmd}"
+    switch = SystemCommandSwitch("pc", "linux")
+    switch.restart()
+    mock_which.assert_called_once_with("reboot")
+    mock_popen.assert_called_once_with(["sudo", "/usr/bin/reboot"])
+
+
+@patch("womgr.entities.subprocess.Popen")
+@patch("womgr.entities.shutil.which")
+def test_system_command_restart_windows(mock_which, mock_popen):
+    mock_which.return_value = None
+    switch = SystemCommandSwitch("pc", "windows")
+    switch.restart()
+    mock_which.assert_called_once_with("shutdown")
+    mock_popen.assert_called_once_with(["shutdown", "/r", "/t", "0"])
+
+
+@patch("womgr.entities.subprocess.Popen")
+@patch("womgr.entities.shutil.which")
+def test_system_command_shutdown_linux(mock_which, mock_popen):
+    mock_which.side_effect = lambda cmd: f"/sbin/{cmd}"
+    switch = SystemCommandSwitch("pc", "linux")
+    switch.shutdown()
+    mock_which.assert_called_once_with("shutdown")
+    mock_popen.assert_called_once_with(["sudo", "/sbin/shutdown", "-h", "now"])
+
+
+@patch("womgr.entities.subprocess.Popen")
+@patch("womgr.entities.shutil.which")
+def test_system_command_shutdown_windows(mock_which, mock_popen):
+    mock_which.return_value = "C:/shutdown.exe"
+    switch = SystemCommandSwitch("pc", "windows")
+    switch.shutdown()
+    mock_which.assert_called_once_with("shutdown")
+    mock_popen.assert_called_once_with(["C:/shutdown.exe", "/s", "/t", "0"])


### PR DESCRIPTION
## Summary
- add tests for WakeOnLanSwitch, PingBinarySensor and SystemCommandSwitch
- test womgr_cli and dashboard_cli argument handling and errors
- cover config flow MAC validation logic

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e7471e008330be0000f6ab09b9ad