### PR TITLE
Add pastel color support for bubble cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ entry = setup_device(
     ip="192.0.2.10",
     location="Office",
     os_type="linux",
+    color="rgb(200, 230, 255)",
 )
 # entry.entities now contains WakeOnLanSwitch,
 # PingBinarySensor and SystemCommandSwitch
@@ -64,6 +65,7 @@ remove_device(entry)
 Wake-on-LAN packets are sent to `<broadcast>` on UDP port `9` by default.
 Use the optional `broadcast` and `port` arguments of `setup_device()` to
 override these values.
+The `color` argument lets you pick a pastel background for the Bubble Card button.
 
 ### CLI Usage
 
@@ -86,7 +88,7 @@ python womgr_cli.py DEVICE_NAME AA:BB:CC:DD:EE:FF 192.0.2.10 Office linux status
 
 ## Home Assistant Integration
 
-Copy the `custom_components/womgr` folder into your Home Assistant `config/custom_components` directory and restart Home Assistant.  Add the **WoMgr** integration from the Integrations page.  The initial setup can be completed without specifying a device so you may install the integration first and add devices later.  Simply run **Add Integration** again for each machine you want to manage and enter its name, MAC address, IP, location and operating system.  Username and password remain optional and are only needed for restart or shutdown commands.  When the first device is added, the integration creates a **HaWoManager** dashboard and inserts a Bubble Card for the device.  Additional devices are appended to the same dashboard automatically.
+Copy the `custom_components/womgr` folder into your Home Assistant `config/custom_components` directory and restart Home Assistant.  Add the **WoMgr** integration from the Integrations page.  The initial setup can be completed without specifying a device so you may install the integration first and add devices later.  Simply run **Add Integration** again for each machine you want to manage and enter its name, MAC address, IP, location and operating system.  Username and password remain optional and are only needed for restart or shutdown commands.  When the first device is added, the integration creates a **HaWoManager** dashboard and inserts a Bubble Card for the device.  Additional devices are appended to the same dashboard automatically. You may also set a pastel color for the device's button.
 
 ### Example Dashboard
 
@@ -116,6 +118,10 @@ cards:
       action: navigate
       navigation_path: '#server'
     show_state: false
+    style: |
+      ha-card {
+        background-color: rgb(200, 230, 255);
+      }
 ```
 
 This example assumes the device was added with the name `server`.
@@ -131,6 +137,12 @@ long-lived access token:
 
 ```bash
 python dashboard_cli.py http://homeassistant.local:8123 YOUR_TOKEN server
+```
+
+Add `--color` to pick a custom pastel color for the device's button:
+
+```bash
+python dashboard_cli.py http://homeassistant.local:8123 YOUR_TOKEN server --color "rgb(200, 230, 255)"
 ```
 
 Repeat the command for additional devices. The script appends a card to the

--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.components.lovelace.dashboard import (
 )
 
 from .core import setup_device, remove_device
+from womgr import pastel_color
 
 from .const import DOMAIN
 
@@ -68,6 +69,7 @@ async def _async_update_dashboard(hass: HomeAssistant, entry: ConfigEntry) -> No
                 raise
 
         view = next((v for v in config.get("views", []) if v.get("path") == "womgr"), None)
+        color = entry.data.get("color") or pastel_color(entry.data["device_name"])
         hash_tag = f"#womgr-{entry.data['device_name']}"
         card = {
             "type": "vertical-stack",
@@ -91,6 +93,7 @@ async def _async_update_dashboard(hass: HomeAssistant, entry: ConfigEntry) -> No
                     "icon": "mdi:server-network",
                     "tap_action": {"action": "navigate", "navigation_path": hash_tag},
                     "show_state": False,
+                    **({"style": f"ha-card {{ background-color: {color}; }}"}),
                 },
             ],
         }

--- a/custom_components/womgr/config_flow.py
+++ b/custom_components/womgr/config_flow.py
@@ -76,6 +76,7 @@ class WoMgrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required("os_type", default="linux"): vol.In(["linux", "windows"]),
                 vol.Optional("username", default=""): str,
                 vol.Optional("password", default=""): str,
+                vol.Optional("color", default=""): str,
             }
         )
 

--- a/dashboard_cli.py
+++ b/dashboard_cli.py
@@ -1,9 +1,10 @@
 import argparse
 import json
 import requests
+from womgr import pastel_color
 
 
-def create_dashboard(url: str, token: str, device_name: str):
+def create_dashboard(url: str, token: str, device_name: str, color: str | None = None):
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
     # Fetch existing Lovelace config
     resp = requests.get(f"{url}/api/lovelace/config", headers=headers, timeout=10)
@@ -12,6 +13,7 @@ def create_dashboard(url: str, token: str, device_name: str):
 
     view = next((v for v in config.get("views", []) if v.get("path") == "womgr"), None)
     hash_tag = f"#womgr-{device_name}"
+    color = color or pastel_color(device_name)
     card = {
         "type": "vertical-stack",
         "title": device_name,
@@ -34,6 +36,7 @@ def create_dashboard(url: str, token: str, device_name: str):
                 "icon": "mdi:server-network",
                 "tap_action": {"action": "navigate", "navigation_path": hash_tag},
                 "show_state": False,
+                "style": f"ha-card {{ background-color: {color}; }}",
             },
         ],
     }
@@ -58,9 +61,10 @@ def main():
     parser.add_argument("url", help="Base URL of Home Assistant, e.g. http://hass:8123")
     parser.add_argument("token", help="Long-Lived Access Token")
     parser.add_argument("device_name", help="Device name used in HaWoManager")
+    parser.add_argument("--color", help="Bubble card background color", default=None)
     args = parser.parse_args()
 
-    create_dashboard(args.url, args.token, args.device_name)
+    create_dashboard(args.url, args.token, args.device_name, args.color)
 
 
 if __name__ == "__main__":

--- a/lovelace/womgr_example.yaml
+++ b/lovelace/womgr_example.yaml
@@ -21,3 +21,7 @@ cards:
       action: navigate
       navigation_path: '#server'
     show_state: false
+    style: |
+      ha-card {
+        background-color: rgb(200, 230, 255);
+      }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -77,6 +77,7 @@ def _valid_input(**overrides):
         "os_type": "linux",
         "username": "",
         "password": "",
+        "color": "",
     }
     data.update(overrides)
     return data

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import unittest
 
-from womgr.util import parse_mac_address
+from womgr.util import parse_mac_address, pastel_color
 
 class TestParseMacAddress(unittest.TestCase):
     def test_valid_mac(self):
@@ -23,6 +23,15 @@ class TestParseMacAddress(unittest.TestCase):
             parse_mac_address("invalid")
         with self.assertRaises(ValueError):
             parse_mac_address("00:11:22:33:44")
+
+
+class TestPastelColor(unittest.TestCase):
+    def test_deterministic(self):
+        self.assertEqual(pastel_color("dev"), pastel_color("dev"))
+
+    def test_format(self):
+        color = pastel_color("dev")
+        self.assertRegex(color, r"rgb\(\d{1,3}, \d{1,3}, \d{1,3}\)")
 
 if __name__ == "__main__":
     unittest.main()

--- a/womgr/__init__.py
+++ b/womgr/__init__.py
@@ -8,6 +8,7 @@ from .entities import (
     setup_device,
     remove_device,
 )
+from .util import pastel_color
 
 __all__ = [
     "ConfigEntry",
@@ -16,4 +17,5 @@ __all__ = [
     "WakeOnLanSwitch",
     "setup_device",
     "remove_device",
+    "pastel_color",
 ]

--- a/womgr/entities.py
+++ b/womgr/entities.py
@@ -27,6 +27,7 @@ class ConfigEntry:
     location: str = ""
     username: str = ""
     password: str = ""
+    color: str = ""
     entities: List["WoMgrEntity"] = field(default_factory=list)
 
     def add_entity(self, entity: "WoMgrEntity") -> None:
@@ -181,6 +182,7 @@ def setup_device(
     os_type: str,
     username: str = "",
     password: str = "",
+    color: str = "",
     broadcast: str = "<broadcast>",
     port: int = 9,
 ) -> ConfigEntry:
@@ -196,6 +198,7 @@ def setup_device(
         os_type=os_type,
         username=username,
         password=password,
+        color=color,
     )
 
     entry.add_entity(WakeOnLanSwitch(device_name, mac, broadcast, port))

--- a/womgr/util.py
+++ b/womgr/util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import hashlib
 
 
 _MAC_RE = re.compile(r"^[0-9A-Fa-f]{2}([:-]?[0-9A-Fa-f]{2}){5}$")
@@ -24,3 +25,12 @@ def parse_mac_address(mac: str) -> bytes:
         return bytes.fromhex(cleaned)
     except ValueError as exc:
         raise ValueError("Invalid MAC address") from exc
+
+
+def pastel_color(seed: str) -> str:
+    """Generate a pastel RGB color based on a seed string."""
+    h = hashlib.md5(seed.encode()).hexdigest()
+    r = (int(h[0:2], 16) + 255) // 2
+    g = (int(h[2:4], 16) + 255) // 2
+    b = (int(h[4:6], 16) + 255) // 2
+    return f"rgb({r}, {g}, {b})"

--- a/womgr_cli.py
+++ b/womgr_cli.py
@@ -25,6 +25,9 @@ def main() -> None:
     parser.add_argument(
         "--password", default="", help="Password for restart/shutdown commands"
     )
+    parser.add_argument(
+        "--color", default="", help="Bubble card background color"
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("wol", help="Send Wake-on-LAN packet")
@@ -55,6 +58,7 @@ def main() -> None:
         os_type=args.os_type,
         username=args.username,
         password=args.password,
+        color=args.color,
     )
 
     wol = next(e for e in entry.entities if isinstance(e, WakeOnLanSwitch))


### PR DESCRIPTION
## Summary
- let integrations specify a pastel `color` for each device
- support `color` option in config flow and CLI
- generate a default pastel color when building dashboard cards
- document example usage and extend tests

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ec23e1148330b6836a8b384145d0