### PR TITLE
Fix package discovery for custom components

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@ setup(
     name='HaWoManager',
     version='0.0.6',
     description='Device management utilities with Home Assistant integration',
-    packages=find_packages(),
+    packages=find_packages(include=[
+        "womgr",
+        "custom_components",
+        "custom_components.*",
+    ]),
     include_package_data=True,
     install_requires=["requests"],
 )


### PR DESCRIPTION
## Summary
- include the Home Assistant integration under `custom_components` when packaging

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d56899dc83308a959068f21fc060