### PR TITLE
Add sidebar panel for WoMgr device setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.9] - 2025-07-12
+### Added
+- Permanent sidebar panel for device management.
+
 ## [0.0.8] - 2025-07-11
 ### Removed
 - CLI functionality and `pip` installation instructions. The integration is now

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Entities created by the utilities follow the naming scheme
 
 ## Home Assistant Integration
 After installing via HACS, add the **WoMgr** integration from the Integrations page. The initial setup can be completed without specifying a device so you may install the integration first and add devices later. Simply run **Add Integration** again for each machine you want to manage and enter its name, MAC address, IP, location and operating system. Username and password remain optional and are only needed for restart or shutdown commands. You can also provide a custom dashboard or view name instead of the default `womgr`. When the first device is added, the integration creates a **HaWoManager** dashboard and inserts a Bubble Card for the device. Additional devices are appended to the chosen dashboard automatically. You may also set a pastel color for the device's button.
-=======
-
 
 ## Usage
 
@@ -93,4 +91,4 @@ This example assumes the device was added with the name `server`.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.8**.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.9**.

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,5 +1,2 @@
 
-# Package marker
-=======
-
- main
+# Package marker for the custom_components namespace

--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -6,6 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 import asyncio
+import os
 from homeassistant.components.lovelace.const import (
     CONF_ALLOW_SINGLE_WORD,
     CONF_ICON,
@@ -153,6 +154,17 @@ async def _async_remove_dashboard_card(hass: HomeAssistant, entry: ConfigEntry) 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the WoMgr component from YAML."""
     hass.data.setdefault(DOMAIN, {})
+
+    panel_path = os.path.join(os.path.dirname(__file__), "www", "panel.html")
+    hass.http.register_static_path("/womgr-panel", panel_path, False)
+    hass.components.frontend.async_register_built_in_panel(
+        "iframe",
+        "HaWoManager",
+        "mdi:server-network",
+        "womgr",
+        {"url": "/womgr-panel"},
+        require_admin=True,
+    )
     return True
 
 

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "config_flow": true,
     "requirements": []
 }

--- a/custom_components/womgr/www/panel.html
+++ b/custom_components/womgr/www/panel.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>HaWoManager</title>
+  <meta charset="utf-8" />
+</head>
+<body>
+  <h1>HaWoManager Devices</h1>
+  <p>
+    Use this page to add or manage WoMgr devices. Click the button below to start
+    the integration flow for a new device.
+  </p>
+  <button onclick="location.href='/config/integrations/dashboard/add?domain=womgr'">
+    Add Device
+  </button>
+</body>
+</html>

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='HaWoManager',
-    version='0.0.8',
+    version='0.0.9',
     description='Device management utilities with Home Assistant integration',
     packages=find_packages(include=[
         "womgr",


### PR DESCRIPTION
## Summary
- add permanent sidebar panel for device management
- bump integration to v0.0.9

## Testing
- `pip install voluptuous`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871846738e883309b1a00d64658c4aa