### PR TITLE
Fix static path registration

### DIFF
--- a/custom_components/womgr/__init__.py
+++ b/custom_components/womgr/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components.lovelace.const import (
     CONF_TITLE,
     CONF_URL_PATH,
 )
+from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.lovelace.dashboard import (
     DashboardsCollection,
     LovelaceStorage,
@@ -156,7 +157,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     panel_path = os.path.join(os.path.dirname(__file__), "www", "panel.html")
-    hass.http.register_static_path("/womgr-panel", panel_path, False)
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig("/womgr-panel", panel_path, False)]
+    )
     hass.components.frontend.async_register_built_in_panel(
         "iframe",
         "HaWoManager",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import types
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 # Stub minimal homeassistant modules required for import
@@ -27,6 +28,15 @@ ha.helpers = types.ModuleType("helpers")
 ha.helpers.typing = types.ModuleType("typing")
 ha.helpers.typing.ConfigType = dict
 ha.components = types.ModuleType("components")
+ha.components.http = types.ModuleType("http")
+
+@dataclass
+class StaticPathConfig:
+    url_path: str
+    path: str
+    cache_headers: bool = True
+
+ha.components.http.StaticPathConfig = StaticPathConfig
 lovelace = types.ModuleType("lovelace")
 lovelace.const = types.SimpleNamespace(
     CONF_ALLOW_SINGLE_WORD="allow_single_word",
@@ -60,6 +70,7 @@ sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
 sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.http", ha.components.http)
 sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
 sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
 sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import types
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 # Stub minimal homeassistant modules required for import
@@ -13,6 +14,15 @@ ha.helpers = types.ModuleType("helpers")
 ha.helpers.typing = types.ModuleType("typing")
 ha.helpers.typing.ConfigType = dict
 ha.components = types.ModuleType("components")
+ha.components.http = types.ModuleType("http")
+
+@dataclass
+class StaticPathConfig:
+    url_path: str
+    path: str
+    cache_headers: bool = True
+
+ha.components.http.StaticPathConfig = StaticPathConfig
 lovelace = types.ModuleType("lovelace")
 lovelace.const = types.SimpleNamespace(
     CONF_ALLOW_SINGLE_WORD="allow_single_word",
@@ -59,6 +69,7 @@ sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
 sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.http", ha.components.http)
 sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
 sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
 sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import types
+from dataclasses import dataclass
 from types import SimpleNamespace
 
 # Stub minimal homeassistant modules required for import
@@ -13,6 +14,15 @@ ha.helpers = types.ModuleType("helpers")
 ha.helpers.typing = types.ModuleType("typing")
 ha.helpers.typing.ConfigType = dict
 ha.components = types.ModuleType("components")
+ha.components.http = types.ModuleType("http")
+
+@dataclass
+class StaticPathConfig:
+    url_path: str
+    path: str
+    cache_headers: bool = True
+
+ha.components.http.StaticPathConfig = StaticPathConfig
 lovelace = types.ModuleType("lovelace")
 lovelace.const = types.SimpleNamespace(
     CONF_ALLOW_SINGLE_WORD="allow_single_word",
@@ -47,6 +57,7 @@ sys.modules.setdefault("homeassistant.core", ha.core)
 sys.modules.setdefault("homeassistant.helpers", ha.helpers)
 sys.modules.setdefault("homeassistant.helpers.typing", ha.helpers.typing)
 sys.modules.setdefault("homeassistant.components", ha.components)
+sys.modules.setdefault("homeassistant.components.http", ha.components.http)
 sys.modules.setdefault("homeassistant.components.lovelace", lovelace)
 sys.modules.setdefault("homeassistant.components.lovelace.const", lovelace.const)
 sys.modules.setdefault("homeassistant.components.lovelace.dashboard", lovelace.dashboard)


### PR DESCRIPTION
## Summary
- use `async_register_static_paths` for panel URL
- stub `StaticPathConfig` in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68761ae15b288330b385ba23f0616fbd