### PR TITLE
Enhance HaWoManager with REST API and updated panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.10] - 2025-07-20
+### Added
+- REST API for device management and JSON import/export.
+- Interactive management panel showing device status and actions.
+- Config flow checks for duplicate IP addresses and allows specifying icon and area.
+
 ## [0.0.9] - 2025-07-12
 ### Added
 - Permanent sidebar panel for device management.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HaWoManager
 
-HaWoManager is a Home Assistant integration for managing network devices using Wake-on-LAN and optional restart or shutdown commands. It automatically creates a dedicated dashboard so your devices appear with status and controls.
+HaWoManager is a Home Assistant integration for managing network devices using Wake-on-LAN and optional restart or shutdown commands. It automatically creates a dedicated dashboard so your devices appear with status and controls. A sidebar entry **Wake On Lan Management** provides a full management UI where devices can be woken, restarted or refreshed directly.
 
 Entities created by the utilities follow the naming scheme
 `womgr_{device_name}_{entity}` so they can easily be grouped by device.
@@ -91,4 +91,4 @@ This example assumes the device was added with the name `server`.
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.9**.
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The latest release is **v0.0.10**.

--- a/custom_components/womgr/api.py
+++ b/custom_components/womgr/api.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+
+class DevicesView(HomeAssistantView):
+    """View to list and control WoMgr devices."""
+
+    url = "/api/womgr/devices"
+    name = "api:womgr:devices"
+    requires_auth = True
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    async def get(self, request):
+        data = []
+        for entry_id, config in self.hass.data.get(DOMAIN, {}).items():
+            device = {
+                "entry_id": entry_id,
+                "device_name": config.device_name,
+                "mac": config.mac,
+                "ip": config.ip,
+                "os_type": config.os_type,
+            }
+            for entity in config.entities:
+                if entity.entity_id.endswith("_ping"):
+                    device["online"] = entity.is_on
+            data.append(device)
+        return self.json(data)
+
+    async def post(self, request):
+        body: dict[str, Any] = await request.json()
+        entry_id = body.get("entry_id")
+        action = body.get("action")
+        if not entry_id or not action:
+            return self.json({"error": "missing parameters"}, status_code=400)
+        config = self.hass.data.get(DOMAIN, {}).get(entry_id)
+        if not config:
+            return self.json({"error": "unknown device"}, status_code=404)
+        if action == "wake":
+            wol = next(e for e in config.entities if e.entity_id.endswith("_wol"))
+            for _ in range(3):
+                await self.hass.async_add_executor_job(wol.turn_on)
+                await asyncio.sleep(1)
+        elif action in ("restart", "shutdown"):
+            sys_entity = next(
+                e for e in config.entities if e.entity_id.endswith("_system")
+            )
+            func = getattr(sys_entity, action)
+            await self.hass.async_add_executor_job(func)
+        elif action == "refresh":
+            ping = next(e for e in config.entities if e.entity_id.endswith("_ping"))
+            await ping.update()
+        else:
+            return self.json({"error": "unknown action"}, status_code=400)
+        return self.json({"success": True})
+
+
+class ExportView(HomeAssistantView):
+    url = "/api/womgr/export"
+    name = "api:womgr:export"
+    requires_auth = True
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    async def get(self, request):
+        entries = [entry.data for entry in self.hass.config_entries.async_entries(DOMAIN) if entry.data]
+        return self.json(entries)
+
+
+class ImportView(HomeAssistantView):
+    url = "/api/womgr/import"
+    name = "api:womgr:import"
+    requires_auth = True
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+
+    async def post(self, request):
+        devices: list[dict[str, Any]] = await request.json()
+        flow = self.hass.config_entries.flow
+        for dev in devices:
+            await flow.async_init(DOMAIN, context={"source": "user"}, data=dev)
+        return self.json({"success": True})

--- a/custom_components/womgr/config_flow.py
+++ b/custom_components/womgr/config_flow.py
@@ -60,6 +60,8 @@ class WoMgrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         return self.async_abort(reason="duplicate_device_name")
                     if entry.data.get("mac") == user_input["mac"]:
                         return self.async_abort(reason="duplicate_mac")
+                    if entry.data.get("ip") == user_input["ip"]:
+                        return self.async_abort(reason="duplicate_ip")
 
             if not errors:
                 return self.async_create_entry(
@@ -78,6 +80,8 @@ class WoMgrConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional("password", default=""): str,
                 vol.Optional("color", default=""): str,
                 vol.Optional("dashboard", default=""): str,
+                vol.Optional("icon", default="mdi:server-network"): str,
+                vol.Optional("area", default=""): str,
             }
         )
 

--- a/custom_components/womgr/manifest.json
+++ b/custom_components/womgr/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "womgr",
     "name": "WoMgr",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "config_flow": true,
     "requirements": []
 }

--- a/custom_components/womgr/www/panel.html
+++ b/custom_components/womgr/www/panel.html
@@ -1,17 +1,72 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>HaWoManager</title>
+  <title>Wake On Lan Management</title>
   <meta charset="utf-8" />
+  <style>
+    body { font-family: sans-serif; margin: 1rem; }
+    .device { border: 1px solid #ccc; padding: 0.5rem; border-radius: 4px; margin-bottom: 1rem; }
+    .device h3 { margin: 0 0 0.5rem 0; }
+    button { margin-right: 0.5rem; }
+  </style>
+  <script>
+    async function loadDevices() {
+      const resp = await fetch('/api/womgr/devices');
+      const devs = await resp.json();
+      const container = document.getElementById('devices');
+      container.innerHTML = '';
+      if (!devs.length) {
+        container.innerHTML = '<p>No devices configured.</p>';
+        return;
+      }
+      devs.sort((a,b)=>a.device_name.localeCompare(b.device_name));
+      for (const d of devs) {
+        const card = document.createElement('div');
+        card.className = 'device';
+        card.innerHTML = `<h3>${d.device_name}</h3>`+
+          `<p>${d.ip} (${d.mac}) - <span class="status">${d.online ? 'Online' : 'Offline'}</span></p>`+
+          `<button onclick="deviceAction('${d.entry_id}','wake')">Wake</button>`+
+          `<button onclick="deviceAction('${d.entry_id}','restart')">Restart</button>`+
+          `<button onclick="deviceAction('${d.entry_id}','refresh')">Refresh</button>`;
+        container.appendChild(card);
+      }
+    }
+    async function deviceAction(id, action) {
+      await fetch('/api/womgr/devices', {method:'POST', body: JSON.stringify({entry_id:id, action})});
+      if (action === 'refresh') loadDevices();
+    }
+    async function exportDevices() {
+      const resp = await fetch('/api/womgr/export');
+      const data = await resp.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob); a.download = 'devices.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }
+    function importDevices() {
+      document.getElementById('importFile').click();
+    }
+    async function handleImport(evt) {
+      const file = evt.target.files[0];
+      if (!file) return;
+      const text = await file.text();
+      await fetch('/api/womgr/import', {method:'POST', body:text});
+      loadDevices();
+    }
+    window.addEventListener('load', loadDevices);
+  </script>
 </head>
 <body>
-  <h1>HaWoManager Devices</h1>
+  <h1>Wake On Lan Management</h1>
+  <div id="devices"></div>
   <p>
-    Use this page to add or manage WoMgr devices. Click the button below to start
-    the integration flow for a new device.
+    <button onclick="location.href='/config/integrations/dashboard/add?domain=womgr'">Add Device</button>
   </p>
-  <button onclick="location.href='/config/integrations/dashboard/add?domain=womgr'">
-    Add Device
-  </button>
+  <p>
+    <button onclick="exportDevices()">Export</button>
+    <button onclick="importDevices()">Import</button>
+    <input id="importFile" type="file" style="display:none" onchange="handleImport(event)">
+  </p>
 </body>
 </html>

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "HaWoManager",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "content_in_root": false,
   "homeassistant": "2023.0.0",
   "render_readme": true

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,8 +13,20 @@ ha.core.HomeAssistant = object
 ha.helpers = types.ModuleType("helpers")
 ha.helpers.typing = types.ModuleType("typing")
 ha.helpers.typing.ConfigType = dict
+ha.helpers.device_registry = types.ModuleType("device_registry")
+ha.helpers.device_registry.async_get = lambda hass: types.SimpleNamespace(
+    async_get_or_create=lambda **kw: types.SimpleNamespace(id="dev"),
+    async_update_device=lambda *a, **k: None,
+)
 ha.components = types.ModuleType("components")
 ha.components.http = types.ModuleType("http")
+class DummyView:
+    name = "dummy"
+    url = "/"
+    requires_auth = False
+    def __init__(self, hass=None):
+        pass
+ha.components.http.HomeAssistantView = DummyView
 
 @dataclass
 class StaticPathConfig:

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -13,8 +13,20 @@ ha.core.HomeAssistant = object
 ha.helpers = types.ModuleType("helpers")
 ha.helpers.typing = types.ModuleType("typing")
 ha.helpers.typing.ConfigType = dict
+ha.helpers.device_registry = types.ModuleType("device_registry")
+ha.helpers.device_registry.async_get = lambda hass: types.SimpleNamespace(
+    async_get_or_create=lambda **kw: types.SimpleNamespace(id="dev"),
+    async_update_device=lambda *a, **k: None,
+)
 ha.components = types.ModuleType("components")
 ha.components.http = types.ModuleType("http")
+class DummyView:
+    name = "dummy"
+    url = "/"
+    requires_auth = False
+    def __init__(self, hass=None):
+        pass
+ha.components.http.HomeAssistantView = DummyView
 
 @dataclass
 class StaticPathConfig:


### PR DESCRIPTION
## Summary
- implement new management REST API
- allow icon, area, and IP duplication check in config flow
- create responsive management panel with import/export
- register devices with device registry and new views
- bump version to 0.0.10

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762c01033c833088b5a18e2cb1f4e4